### PR TITLE
Added workingDirectory configuration option with tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,22 @@ module.exports = function(grunt) {
                 src: ['**'],
                 dest: 'tmp/vanilla/'
             },
+            prepareVanillaCwd: {
+                files: [
+                    {
+                        expand: true,
+                        cwd: 'test/fixture/vanilla/src/static',
+                        src: ['**'],
+                        dest: 'tmp/vanillaCwd/src/static/extrafolder'
+                    },
+                    {
+                        expand: true,
+                        cwd: 'test/fixture/vanilla/target-grunt',
+                        src: ['**'],
+                        dest: 'tmp/vanillaCwd/target-grunt'
+                    }
+                ]
+            },
             prepareOverrides: {
                 expand: true,
                 cwd: 'test/fixture/overrides/',
@@ -45,6 +61,11 @@ module.exports = function(grunt) {
             chdirToVanilla: {
                 call: function() {
                     process.chdir('tmp/vanilla/target-grunt');
+                }
+            },
+            chdirToVanillaCwd: {
+                call: function() {
+                    process.chdir('tmp/vanillaCwd/target-grunt');
                 }
             },
             chdirToOverrides: {
@@ -64,6 +85,11 @@ module.exports = function(grunt) {
                     resources: ['**']
                 }
             },
+            should_prepare_grunt_dist_and_copy_to_maven_dist_cwd: {
+                options: {
+                    resources: ['**']
+                }
+            },
             should_prepare_grunt_dist_and_copy_to_maven_dist_with_overriden_properties: {
                 options: {
                     resources: ['**']
@@ -74,6 +100,14 @@ module.exports = function(grunt) {
             should_prepare_grunt_dist_and_copy_to_maven_dist: {
                 options: {
                     warName: 'war',
+                    deliverables: ['**', '!non-deliverable.js'],
+                    gruntDistDir: 'dist'
+                }
+            },
+            should_prepare_grunt_dist_and_copy_to_maven_dist_cwd: {
+                options: {
+                    warName: 'war',
+                    workingDirectory: 'extrafolder',
                     deliverables: ['**', '!non-deliverable.js'],
                     gruntDistDir: 'dist'
                 }
@@ -106,6 +140,13 @@ module.exports = function(grunt) {
         'execute:chdirReset'
     ]);
 
+    grunt.registerTask('testVanillaCwd', [
+        'execute:chdirToVanillaCwd',
+        'mavenPrepare:should_prepare_grunt_dist_and_copy_to_maven_dist_cwd',
+        'mavenDist:should_prepare_grunt_dist_and_copy_to_maven_dist_cwd',
+        'execute:chdirReset'
+    ]);
+
     grunt.registerTask('testOverrides', [
         'execute:chdirToOverrides',
         'mavenPrepare:should_prepare_grunt_dist_and_copy_to_maven_dist_with_overriden_properties',
@@ -113,7 +154,7 @@ module.exports = function(grunt) {
         'execute:chdirReset'
     ]);
 
-    grunt.registerTask('test', ['clean', 'copy', 'testVanilla', 'testOverrides', 'nodeunit']);
+    grunt.registerTask('test', ['clean', 'copy', 'testVanilla', 'testVanillaCwd', 'testOverrides', 'nodeunit']);
 
     grunt.registerTask('default', ['jshint', 'test']);
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ Type: `Array`
 List of patterns that will be evaluated using [minimatch](https://github.com/isaacs/minimatch) to choose deliverables that
 will be copied from `target-grunt/` to `target-grunt/dist` and to WAR.
 
+#### options.workingDirectory
+Type: `String`
+Default: Directory where gruntfile is located
+
+Deliverable patterns will be matched relative to this path, and all returned filepaths will also be relative to this path.
+
 #### options.gruntDistDir
 Type: `String`
 Default: `dist`

--- a/tasks/maven.js
+++ b/tasks/maven.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
 
         grunt.verbose.subhead('Directories');
 
-        var workPath = path.resolve(process.cwd());
+        var workPath = config.workingDirectory ? path.resolve(config.workingDirectory) : path.resolve(process.cwd());
         grunt.verbose.writeln('-> Grunt working directory: ' + workPath);
 
         var gruntDistPath = path.resolve(gruntDistDir);

--- a/test/maven_test.js
+++ b/test/maven_test.js
@@ -52,7 +52,6 @@ exports.maven = {
 
         test.done();
     },
-
     should_prepare_grunt_dist_and_copy_to_maven_dist_with_overriden_properties: function(test) {
         var expectedFiles = [
             'target-grunt/code.js',
@@ -79,5 +78,33 @@ exports.maven = {
         });
 
         test.done();
-    }
+    },
+    should_prepare_grunt_dist_and_copy_to_maven_dist_cwd: function(test) {
+        var expectedFiles = [
+            'target-grunt/code.js',
+            'target-grunt/css/style.css',
+            'target-grunt/dist/code.js',
+            'target-grunt/dist/css/style.css',
+            'target/war/static/code.js',
+            'target/war/static/css/style.css',
+        ];
+
+        var invalidFiles = [
+            'target-grunt/dist/grunt-maven-custom.json',
+            'target-grunt/dist/non-deliverable.js',
+            'target-grunt/maven-protected.json'
+        ];
+
+        test.expect(expectedFiles.length + invalidFiles.length);
+
+        _.forEach(expectedFiles, function(file) {
+            test.ok(grunt.file.exists('tmp/vanilla/' + file), 'Expected to see ' + file + ' in tmp/vanillaCwd/, but none found.');
+        });
+
+        _.forEach(invalidFiles, function(file) {
+            test.ok(!grunt.file.exists('tmp/vanilla/' + file), 'Did not want to see ' + file + ' in tmp/vanillaCwd/, but yet it was found.');
+        });
+
+        test.done();
+    },
 };


### PR DESCRIPTION
I added a workingDirectory configuration option to help with copying proper relative paths from the deliverables globs. That way if gruntfile compiles its own dist directory it can be copied easily with **

Open to debate and feedback
